### PR TITLE
Clarify what years are covered and that this is no longer real-time.

### DIFF
--- a/index.html
+++ b/index.html
@@ -13756,14 +13756,14 @@ textarea.sos-source {
       </div><div class="cell border-box-sizing text_cell rendered">
       <div class="inner_cell">
       <div class="text_cell_render border-box-sizing rendered_html">
-      <h1 id="Real-time-$R_t$-of-COVID-19-pandemic-in-the-Greater-Houston-Area-(Until-09/09)">Real-time $R_t$ of COVID-19 pandemic in the Greater Houston Area (Until 09/09)<a class="anchor-link" href="#Real-time-$R_t$-of-COVID-19-pandemic-in-the-Greater-Houston-Area-(Until-09/09)">&#182;</a></h1>
+      <h1 id="Real-time-$R_t$-of-COVID-19-pandemic-in-the-Greater-Houston-Area-(Until-09/09)">Daily $R_t$ of COVID-19 pandemic in the Greater Houston Area (Until 2021-09-09)<a class="anchor-link" href="#Real-time-$R_t$-of-COVID-19-pandemic-in-the-Greater-Houston-Area-(Until-09/09)">&#182;</a></h1>
       </div>
       </div>
       </div><div class="cell border-box-sizing text_cell rendered">
       <div class="inner_cell">
       <div class="text_cell_render border-box-sizing rendered_html">
       <p>This report estimates the county level real-time effective production number ($R_t$) of the COVID-19 pandemic in Texas, based on data from 
-<a href="https://www.dshs.state.tx.us/coronavirus/">the Texas Health and Human Services</a>. This report is updated daily with the most recent version available at the ICTR website.</p>
+<a href="https://www.dshs.state.tx.us/coronavirus/">the Texas Health and Human Services</a>. This report was updated daily in 2020-2021 with the most recent version available at the ICTR website.</p>
 <p>This report is created and maintained by data scientists
 from the <a href="https://www.bcm.edu/research/research-offices/institute-for-clinical-translational-research">Institute for Clinical &amp; Translational Research, Baylor College of Medicine</a>, with an algorithm that is based on <a href="https://github.com/k-sys/covid-19">Kevin Systrom's work</a> for the US data. Please refer to the original report for details.</p>
 
@@ -13772,7 +13772,7 @@ from the <a href="https://www.bcm.edu/research/research-offices/institute-for-cl
       </div><div class="cell border-box-sizing text_cell rendered">
       <div class="inner_cell">
       <div class="text_cell_render border-box-sizing rendered_html">
-      <h2 id="Daily-new-cases-and-real-time-$R_t$-for-Harris-County">Daily new cases and real time $R_t$ for Harris County<a class="anchor-link" href="#Daily-new-cases-and-real-time-$R_t$-for-Harris-County">&#182;</a></h2>
+      <h2 id="Daily-new-cases-and-real-time-$R_t$-for-Harris-County">Daily new cases and $R_t$ for Harris County (2020-2021)<a class="anchor-link" href="#Daily-new-cases-and-real-time-$R_t$-for-Harris-County">&#182;</a></h2>
       </div>
       </div>
       </div>
@@ -13814,7 +13814,7 @@ height=334
 <div class="cell border-box-sizing text_cell rendered">
       <div class="inner_cell">
       <div class="text_cell_render border-box-sizing rendered_html">
-      <p>Here are estimated $R_t$ in the past 15 days:</p>
+      <p>Here are estimated $R_t$ in August and September 2021:</p>
 
       </div>
       </div>
@@ -14011,7 +14011,7 @@ height=334
 <div class="cell border-box-sizing text_cell rendered">
       <div class="inner_cell">
       <div class="text_cell_render border-box-sizing rendered_html">
-      <h2 id="Daily-new-cases-and-real-time-$R_t$-for-counties-in-the-Greater-Houston-Area">Daily new cases and real time $R_t$ for counties in the Greater Houston Area<a class="anchor-link" href="#Daily-new-cases-and-real-time-$R_t$-for-counties-in-the-Greater-Houston-Area">&#182;</a></h2>
+      <h2 id="Daily-new-cases-and-real-time-$R_t$-for-counties-in-the-Greater-Houston-Area">Daily new cases and $R_t$ for counties in the Greater Houston Area (2020-2021)<a class="anchor-link" href="#Daily-new-cases-and-real-time-$R_t$-for-counties-in-the-Greater-Houston-Area">&#182;</a></h2>
       </div>
       </div>
       </div>
@@ -14053,7 +14053,7 @@ height=208
 <div class="cell border-box-sizing text_cell rendered">
       <div class="inner_cell">
       <div class="text_cell_render border-box-sizing rendered_html">
-      <h3 id="Most-recent-$R_t$-by-county">Most recent $R_t$ by county<a class="anchor-link" href="#Most-recent-$R_t$-by-county">&#182;</a></h3>
+      <h3 id="Most-recent-$R_t$-by-county">Most recent $R_t$ as of 2021 by county<a class="anchor-link" href="#Most-recent-$R_t$-by-county">&#182;</a></h3>
       </div>
       </div>
       </div>


### PR DESCRIPTION
The existing public site at https://ictr.github.io/covid-19-county-R0/ could be ambiguous, especially since it is now close to September 2022.

The year "2021" is mentioned only in the data table about halfway down the page. Several prominent places use the wording "real time." This pull request makes minor edits to text in `index.html` to make the years more explicit.

What this PR does not address:
- Did not change the upstream source (meaning I did not edit any ipynb files or run `update_report.sh` which executes `sos convert Realtime_updated.ipynb index.html`.
- X axes on time series plots are labeled only with months (not years).
- Does not change the wording in the HTML anchors.
- Did not change other files in the repo.

This PR is only a temporary measure or placeholder. The "right way" would be to edit the ipynb and re-run, or at minimum, re-run the script to get fresh Excel data from the state of Texas, and update the public-facing website.